### PR TITLE
Refactor scrubber interface and writer registry

### DIFF
--- a/sanitize_text/cli/io.py
+++ b/sanitize_text/cli/io.py
@@ -22,19 +22,20 @@ def read_input_source(
     append: bool,
     output_path: str | None,
 ) -> str:
-    """Return input text selected from CLI sources.
+    """Return input text resolved from CLI sources.
 
     Args:
-        text: Inline text from --text/-t.
-        input_path: Path to an input file.
-        append: Whether to re-use output file as input.
-        output_path: Output path used when append is true.
+        text: Inline text provided via ``--text``/``-t``.
+        input_path: Path to a file provided via ``--input``/``-i``.
+        append: Whether to treat the output file as input when ``True``.
+        output_path: Path used when ``append`` is set.
 
     Returns:
-        The resolved input text.
+        str: Materialized input text.
 
     Raises:
-        ValueError: If append is requested without output, or input is missing.
+        ValueError: If append is requested without an output path or if no
+        usable input source is provided.
     """
     if append and not output_path:
         raise ValueError("--append requires --output to be specified")
@@ -71,10 +72,14 @@ def read_input_source(
 
 
 def infer_output_format(output: str | None, explicit_format: str | None) -> str:
-    """Infer output format from explicit flag or output file extension.
+    """Return the output format resolved from CLI arguments.
+
+    Args:
+        output: Destination path chosen by the user.
+        explicit_format: Explicit ``--output-format`` flag.
 
     Returns:
-        The resolved output format string ("txt", "docx", or "pdf").
+        str: Resolved output format (``"txt"``, ``"docx"``, or ``"pdf"``).
     """
     if explicit_format:
         return explicit_format
@@ -89,10 +94,14 @@ def infer_output_format(output: str | None, explicit_format: str | None) -> str:
 
 
 def maybe_cleanup(text: str, enabled: bool) -> str:
-    """Optionally apply cleanup to the final output text.
+    """Return text after optional cleanup.
+
+    Args:
+        text: Text to post-process.
+        enabled: When ``True`` the cleanup pipeline is executed.
 
     Returns:
-        The cleaned (or original) output text depending on ``enabled``.
+        str: Cleaned text (or the original text when cleanup is disabled).
     """
     return cleanup_output(text) if enabled else text
 
@@ -106,10 +115,18 @@ def write_output(
     pdf_font: str | None,
     font_size: int,
 ) -> str:
-    """Write output using the selected writer and return the output path.
+    """Write scrubbed text and return the path used.
+
+    Args:
+        text: Scrubbed text to persist.
+        output: Optional output path supplied by the user.
+        fmt: Output format resolved from CLI flags.
+        pdf_mode: Layout mode for PDF output.
+        pdf_font: Optional font path for PDF output.
+        font_size: Font size used for PDF output.
 
     Returns:
-        The final output path used for writing the artifact.
+        str: Final path containing the written artifact.
     """
     if output is None:
         output_dir = Path.cwd() / "output"

--- a/sanitize_text/cli/main.py
+++ b/sanitize_text/cli/main.py
@@ -42,7 +42,11 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 def _print_detectors() -> None:
-    """Print available detectors grouped by generic and locale-specific."""
+    """Print available detector descriptions to stdout.
+
+    Outputs both the generic detector catalogue and per-locale detectors for
+    human reference.
+    """
     generic_detectors = get_generic_detector_descriptions()
     locale_detectors = get_available_detectors()
 
@@ -69,10 +73,18 @@ def _run_scrub(
     cleanup: bool,
     verbose: bool,
 ) -> str:
-    """Run scrubbing and return the scrubbed text, optionally verbose-printing.
+    """Return scrubbed text for the requested configuration.
+
+    Args:
+        input_text: Raw text supplied by the user.
+        locale: Optional locale identifier restricting processing.
+        detectors: Whitespace-separated detector names from the CLI.
+        custom: Optional custom detector text configured by the user.
+        cleanup: Whether to normalize the final text with cleanup helpers.
+        verbose: Whether to emit detector progress information.
 
     Returns:
-        The final scrubbed text (possibly cleaned) joined across locales.
+        str: Final scrubbed text (including optional cleanup processing).
     """
     selected_detectors = detectors.split() if detectors else None
     outcome = scrub_text(

--- a/sanitize_text/output.py
+++ b/sanitize_text/output.py
@@ -1,4 +1,4 @@
-"""Output writers implementing the Strategy pattern.
+"""Output writers for different artifact formats.
 
 Each writer converts scrubbed text into a concrete artifact (txt, docx, pdf).
 This extracts side-effectful I/O from the CLI so core logic remains clean.
@@ -12,36 +12,44 @@ from typing import Protocol
 
 
 class OutputWriter(Protocol):
-    """Common interface for all writers."""
+    """Protocol for objects that persist scrubbed text."""
 
-    def write(self, text: str, output: str | Path, **_: object) -> None:
-        """Write *text* to a UTF-8 file."""
-        """Write *text* to *output* path."""
+    def write(self, text: str, output: str | Path, **kwargs: object) -> None:
+        """Persist ``text`` to ``output``.
+
+        Args:
+            text: Scrubbed text to persist.
+            output: Destination path for the artifact.
+            **kwargs: Writer-specific options (format dependent).
+        """
 
 
 class _BaseWriter(abc.ABC):
-    """Abstract helper base with path handling."""
+    """Abstract base class providing filesystem helpers."""
 
     def _prepare_path(self, output: str | Path) -> Path:
+        """Ensure parent directories exist and return a ``Path`` instance.
+
+        Args:
+            output: Destination path provided by the caller.
+
+        Returns:
+            Path: Normalized path pointing to the output file.
+        """
         path = Path(output)
         path.parent.mkdir(parents=True, exist_ok=True)
         return path
 
 
 class TxtWriter(_BaseWriter):
-    """Write plain UTF-8 text files.
+    """Writer implementation for UTF-8 text files."""
 
-    Args:
-        text: The text to write
-        output: The output file path
-    """
-
-    def write(self, text: str, output: str | Path, **kwargs: object) -> None:  # noqa: D401
-        """Write *text* to a UTF-8 file.
+    def write(self, text: str, output: str | Path, **kwargs: object) -> None:
+        """Persist ``text`` to ``output`` using UTF-8 encoding.
 
         Args:
-            text: The text to write.
-            output: The output file path.
+            text: Text to write.
+            output: Path that will receive the text file.
             **kwargs: Additional writer-specific options (unused).
         """
         path = self._prepare_path(output)
@@ -49,18 +57,18 @@ class TxtWriter(_BaseWriter):
 
 
 class DocxWriter(_BaseWriter):
-    """Write a simple DOCX with one paragraph per line."""
+    """Writer implementation for DOCX artifacts."""
 
-    def write(self, text: str, output: str | Path, **kwargs: object) -> None:  # noqa: D401
-        """Write *text* to a DOCX file.
+    def write(self, text: str, output: str | Path, **kwargs: object) -> None:
+        """Persist ``text`` to ``output`` as a DOCX document.
 
         Args:
-            text: The text to write
-            output: The output file path
+            text: Text to write.
+            output: Path that will receive the DOCX document.
             **kwargs: Additional writer-specific options (unused).
 
         Raises:
-            RuntimeError: If python-docx is not installed
+            RuntimeError: If ``python-docx`` is not available.
         """
         try:
             import docx  # type: ignore
@@ -75,10 +83,20 @@ class DocxWriter(_BaseWriter):
 
 
 class PdfWriter(_BaseWriter):
-    """Write a simple PDF using reportlab."""
+    """Writer implementation for PDF artifacts using ReportLab."""
 
-    def write(self, text: str, output: str | Path, **kwargs: object) -> None:  # noqa: D401
-        """Write *text* to a PDF via ReportLab (supports pre/para modes)."""
+    def write(self, text: str, output: str | Path, **kwargs: object) -> None:
+        """Persist ``text`` to ``output`` as a PDF document.
+
+        Args:
+            text: Text to write.
+            output: Path that will receive the PDF document.
+            **kwargs: Writer options such as ``pdf_mode``, ``pdf_font`` and
+                ``font_size``.
+
+        Raises:
+            RuntimeError: If the ReportLab dependency is missing.
+        """
 
         pdf_mode = str(kwargs.get("pdf_mode", "pre"))
         pdf_font_value = kwargs.get("pdf_font")
@@ -167,16 +185,16 @@ _WRITERS: dict[str, OutputWriter] = {
 
 
 def get_writer(fmt: str) -> OutputWriter:
-    """Return an `OutputWriter` for *fmt*.
+    """Return a writer for the requested format.
 
     Args:
-        fmt: Desired format string (txt, docx, pdf).
+        fmt: Desired format string (``"txt"``, ``"docx"``, or ``"pdf"``).
 
     Returns:
-        An `OutputWriter` instance.
+        OutputWriter: Writer implementation associated with ``fmt``.
 
     Raises:
-        ValueError: If *fmt* is unsupported.
+        ValueError: If ``fmt`` is unsupported.
     """
     key = fmt.lower()
     if key not in _WRITERS:


### PR DESCRIPTION
## Summary
- register scrubber detectors through data-driven specifications and return structured `ScrubOutcome` objects for callers
- move locale formatting and progress messaging into the CLI while reporting failures consistently
- normalize writer interfaces by accepting `**kwargs` in `PdfWriter` and only forwarding PDF-specific options when needed

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69108b96ddfc832ba77b53536b9384d5)