### PR TITLE
feat ✨: Add Markdown MIME type support to webui download functionality

### DIFF
--- a/sanitize_text/webui/routes.py
+++ b/sanitize_text/webui/routes.py
@@ -576,6 +576,7 @@ def init_routes(app: Flask) -> Flask:
         download_name = f"scrubbed{suffix}"
         mimetypes = {
             "txt": "text/plain",
+            "md": "text/markdown",
             "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "pdf": "application/pdf",
         }


### PR DESCRIPTION
This commit adds the "text/markdown" MIME type mapping for .md file downloads in the web UI routes. This ensures that Markdown files are served with the correct Content-Type header when users download sanitized content in Markdown format.