### PR TITLE
Default scrubbing to nl_NL and remove locale headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This runs `flask run --reload` in a container, also exposed on `http://localhost
 
 Key options that control how scrubbing behaves:
 
-- `--locale / -l`: Locale code (`nl_NL` or `en_US`). When omitted, the core can process both locales.
+- `--locale / -l`: Locale code (`nl_NL` or `en_US`). When omitted, the core defaults to `nl_NL`.
 - `--detectors / -d`: Space-separated detector names (for example `"email url name"`).
 - `--custom / -c`: Custom text fragment that should always be treated as PII.
 - `--cleanup/--no-cleanup`: Enable or disable final cleanup and normalization.
@@ -174,7 +174,7 @@ Common options:
 - `-t, --text`: Inline input text.
 - `-i, --input`: Path to an input file to scrub.
 - `-o, --output`: Output path (defaults to `$PWD/output/scrubbed.txt`).
-- `-l, --locale`: Locale (`nl_NL` or `en_US`).
+- `-l, --locale`: Locale (`nl_NL` or `en_US`). Defaults to `nl_NL` when omitted.
 - `-d, --detectors`: Space-separated detector names.
 - `-a, --append`: Append to an existing output file instead of overwriting.
 - `--output-format`: Explicit format (`txt`, `md`, `docx`, `pdf`).

--- a/sanitize_text/cli/main.py
+++ b/sanitize_text/cli/main.py
@@ -32,6 +32,7 @@ from sanitize_text.cli.io import (
     write_output,
 )
 from sanitize_text.core.scrubber import (
+    DEFAULT_LOCALE,
     get_available_detectors,
     get_generic_detector_descriptions,
     scrub_text,
@@ -95,13 +96,9 @@ def _run_scrub(
         custom_text=custom,
         verbose=verbose,
     )
-    locales_to_process = [locale] if locale else ["en_US", "nl_NL"]
+    locales_to_process = [locale] if locale else [DEFAULT_LOCALE]
 
-    formatted_sections = [
-        f"Results for {loc}:\n{outcome.texts[loc]}"
-        for loc in locales_to_process
-        if loc in outcome.texts
-    ]
+    formatted_sections = [outcome.texts[loc] for loc in locales_to_process if loc in outcome.texts]
     scrubbed_text = "\n\n".join(formatted_sections)
     scrubbed_text = maybe_cleanup(scrubbed_text, cleanup)
 
@@ -223,7 +220,9 @@ def _run_scrub(
     "--locale",
     "-l",
     type=click.Choice(["nl_NL", "en_US"]),
-    help="Locale for text processing. Processes both if not specified.",
+    help=(
+        "Locale for text processing. Defaults to the nl_NL pipeline when no locale is provided."
+    ),
     metavar="<locale>",
 )
 @click.option(
@@ -352,7 +351,7 @@ def main(
         spinner.start()
 
     if verbose:
-        target_locales = locale if locale is not None else "en_US and nl_NL"
+        target_locales = locale if locale is not None else DEFAULT_LOCALE
         click.echo(f"[Starting scrub for locale(s): {target_locales}]")
         if detectors:
             click.echo(f"[Requested detectors: {detectors}]")

--- a/sanitize_text/core/scrubber.py
+++ b/sanitize_text/core/scrubber.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_LOCALE = "nl_NL"
+
+
 @dataclass(frozen=True)
 class DetectorContext:
     """Context passed to detector factories.
@@ -336,12 +339,12 @@ def get_generic_detector_descriptions(locale: str | None = None) -> dict[str, st
 
     Args:
         locale: Optional locale identifier used to check conditional
-            availability. Defaults to ``"en_US"`` when omitted.
+            availability. Defaults to :data:`DEFAULT_LOCALE` when omitted.
 
     Returns:
         dict[str, str]: Mapping of detector names to descriptions.
     """
-    context = DetectorContext(locale=locale or "en_US")
+    context = DetectorContext(locale=locale or DEFAULT_LOCALE)
     return {spec.name: spec.description for spec in _iter_enabled_specs(GENERIC_DETECTORS, context)}
 
 
@@ -484,13 +487,13 @@ def run_multi_locale_scrub(
     verbose: bool = False,
     include_filth: bool = False,
 ) -> MultiLocaleResult:
-    """Return scrubbed text (and optional filth) for one or both locales.
+    """Return scrubbed text (and optional filth) for the requested locale.
 
     This helper encapsulates the repeated pattern of multi-locale processing:
     building the locale list, constructing scrubbers, applying optional
     cleanup, and (optionally) collecting filth for inspection.
     """
-    locales_to_process = ["en_US", "nl_NL"] if locale is None else [locale]
+    locales_to_process = [DEFAULT_LOCALE] if locale is None else [locale]
     results: list[LocaleResult] = []
     errors: dict[str, str] = {}
 
@@ -545,8 +548,8 @@ def scrub_text(
 
     Args:
         text: Raw text to scrub.
-        locale: Optional locale identifier. When omitted, both Dutch and
-            English locales are processed.
+        locale: Optional locale identifier. When omitted, the default locale
+            :data:`DEFAULT_LOCALE` is processed.
         selected_detectors: Optional list of detector names. When ``None`` the
             default detectors for each locale are used.
         custom_text: Optional custom text treated as PII.
@@ -562,7 +565,7 @@ def scrub_text(
     scrubbed_texts: dict[str, str] = {}
     detectors_by_locale: dict[str, list[str]] = {}
     errors: dict[str, str] = {}
-    locales_to_process = ["en_US", "nl_NL"] if locale is None else [locale]
+    locales_to_process = [DEFAULT_LOCALE] if locale is None else [locale]
     for current_locale in locales_to_process:
         try:
             scrubber = setup_scrubber(current_locale, selected_detectors, custom_text, verbose)
@@ -590,7 +593,7 @@ def collect_filth(
 
     Args:
         text: The text to analyse.
-        locale: Optional locale (default: both).
+        locale: Optional locale (default: :data:`DEFAULT_LOCALE`).
         selected_detectors: Optional list of detectors.
         custom_text: Optional custom text.
 
@@ -601,7 +604,7 @@ def collect_filth(
     from scrubadub import filth as _filth  # noqa: F401  # imported for typing only
 
     out: dict[str, list[scrubadub.filth.Filth]] = {}
-    locales_to_process = [locale] if locale else ["en_US", "nl_NL"]
+    locales_to_process = [locale] if locale else [DEFAULT_LOCALE]
 
     for current_locale in locales_to_process:
         scrubber = setup_scrubber(current_locale, selected_detectors, custom_text)

--- a/sanitize_text/webui/helpers.py
+++ b/sanitize_text/webui/helpers.py
@@ -88,9 +88,8 @@ def format_results_text(results: list[dict[str, str]]) -> str:
     """
     sections: list[str] = []
     for item in results:
-        loc = item.get("locale", "?")
         text = item.get("text", "")
-        sections.append(f"Results for {loc}:\n{text}")
+        sections.append(text)
     return "\n\n".join(sections)
 
 

--- a/sanitize_text/webui/static/script.js
+++ b/sanitize_text/webui/static/script.js
@@ -283,7 +283,7 @@ document.addEventListener('DOMContentLoaded', () => {
         
         const verboseOn = document.getElementById('verbose-check').checked;
         const parts = data.results.map(r => {
-            let section = `--- Results for ${r.locale} ---\n${r.text}`;
+            let section = `${r.text}`;
             if (verboseOn && r.filth) {
                 section += `\n\n[VERBOSE LOG]\n` + r.filth.map(f => `- ${f.type}: "${f.text}" -> "${f.replacement}"`).join('\n');
             }

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -127,9 +127,9 @@ def test_run_scrub_basic_non_verbose(monkeypatch) -> None:
 
     class DummyOutcome:
         def __init__(self) -> None:
-            self.texts = {"en_US": "EN", "nl_NL": "NL"}
+            self.texts = {mod.DEFAULT_LOCALE: "NL"}
             self.errors = {}
-            self.detectors = {"en_US": ["email"]}
+            self.detectors = {mod.DEFAULT_LOCALE: ["email"]}
 
     monkeypatch.setattr(mod, "scrub_text", lambda *a, **k: DummyOutcome())
     monkeypatch.setattr(mod, "maybe_cleanup", lambda text, enabled: text)
@@ -142,7 +142,7 @@ def test_run_scrub_basic_non_verbose(monkeypatch) -> None:
         cleanup=True,
         verbose=False,
     )
-    assert "Results for en_US:\nEN" in out and "Results for nl_NL:\nNL" in out
+    assert out == "NL"
 
 
 def test_run_scrub_verbose_logs_and_collects(monkeypatch) -> None:
@@ -151,9 +151,9 @@ def test_run_scrub_verbose_logs_and_collects(monkeypatch) -> None:
 
     class DummyOutcome:
         def __init__(self) -> None:
-            self.texts = {"en_US": "EN"}
+            self.texts = {mod.DEFAULT_LOCALE: "NL"}
             self.errors = {}
-            self.detectors = {"en_US": ["email", "url"]}
+            self.detectors = {mod.DEFAULT_LOCALE: ["email", "url"]}
 
     monkeypatch.setattr(mod, "scrub_text", lambda *a, **k: DummyOutcome())
     monkeypatch.setattr(mod, "maybe_cleanup", lambda text, enabled: text)
@@ -181,8 +181,8 @@ def test_run_scrub_verbose_logs_and_collects(monkeypatch) -> None:
     result = runner.invoke(_runner_cmd)
 
     assert result.exit_code == 0
-    assert "[Processing locale: en_US]" in result.output
-    assert "Results for en_US:\nEN" in result.output
+    assert f"[Processing locale: {mod.DEFAULT_LOCALE}]" in result.output
+    assert "NL" in result.output
 
 
 def test_main_error_from_read_input_source(monkeypatch) -> None:

--- a/tests/test_normalize_pdf.py
+++ b/tests/test_normalize_pdf.py
@@ -24,13 +24,13 @@ def test_remove_form_feeds_and_trim_trailing_spaces() -> None:
 
 def test_insert_h1_if_missing() -> None:
     """If no H1 is present, insert a top-level heading as first content."""
-    src = "Results for en_US:\nBody"
-    out = normalize_pdf_text(src, title="Results (en_US)")
+    src = "Body"
+    out = normalize_pdf_text(src, title="Results (nl_NL)")
     lines = out.splitlines()
     assert lines[0].startswith("# ")
-    assert lines[0] == "# Results (en_US)"
+    assert lines[0] == "# Results (nl_NL)"
     assert lines[1] == ""
-    assert lines[2] == "Results for en_US:"
+    assert lines[2] == "Body"
 
 
 def test_preserve_existing_h1() -> None:

--- a/tests/test_webui_routes_helpers.py
+++ b/tests/test_webui_routes_helpers.py
@@ -55,8 +55,7 @@ def test_format_results_text_combines_sections() -> None:
         {"locale": "en_US", "text": "Foo"},
         {"locale": "nl_NL", "text": "Bar"},
     ])
-    assert "Results for en_US:" in combined and "Foo" in combined
-    assert "Results for nl_NL:" in combined and "Bar" in combined
+    assert combined == "Foo\n\nBar"
 
 
 def test_read_uploaded_file_to_text_plain_and_pdf(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- default to the nl_NL pipeline when no locale is provided across the CLI, core scrubber, and documentation
- remove locale header prefixes from CLI and Web UI output formatting
- adjust normalization helpers and tests to align with the headerless output

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69232a36bbd4832b9969002d55bd1fac)